### PR TITLE
Fixed issue where code pulled directly from github makes a warning

### DIFF
--- a/DNS-handout/queueTest.c
+++ b/DNS-handout/queueTest.c
@@ -99,8 +99,8 @@ int main(int argc, char* argv[]){
     }
 
     /* Test that push fails when full */
-    if(!queue_push(&q, payload_in[0])
-       == QUEUE_FAILURE){
+    if(!(queue_push(&q, payload_in[0])
+       == QUEUE_FAILURE)){
 	fprintf(stderr,
 		"error: queue_push did not fail"
 		" when full!\n");


### PR DESCRIPTION
This code will make a warning about a boolean compared to -1 never succeeding. The parentheses on the test where queue_push is called on a full queue doesn't properly wrap the correct portion of the code. 